### PR TITLE
Fix packaging of office-word-mcp-server

### DIFF
--- a/office_word_mcp_server/__init__.py
+++ b/office_word_mcp_server/__init__.py
@@ -1,4 +1,3 @@
-"""Office Word MCP Server package entry point."""
 from word_document_server.main import run_server
 
 __all__ = ["run_server"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ dependencies = [
 "Bug Tracker" = "https://github.com/GongRzhe/Office-Word-MCP-Server.git/issues"
 
 [tool.hatch.build.targets.wheel]
-only-include = ["word_document_server"]
+only-include = [
+    "word_document_server",
+    "office_word_mcp_server",
+]
 sources = ["."]
 
 [project.scripts]


### PR DESCRIPTION
### Summary

- expose a dedicated office_word_mcp_server package
- update root package to export run_server
- include the new package in the build configuration


Fix #17 