### PR TITLE
Feature/add lines and paragraphs

### DIFF
--- a/word_document_server/main.py
+++ b/word_document_server/main.py
@@ -111,6 +111,15 @@ def register_tools():
         """List all .docx files in the specified directory."""
         return document_tools.list_available_documents(directory)
     
+    @mcp.tool()
+    def get_document_xml(filename: str):
+        """Get the raw XML structure of a Word document."""
+        return document_tools.get_document_xml_tool(filename)
+    
+    @mcp.tool()
+    def insert_header_near_text(filename: str, target_text: str, header_title: str, position: str = 'after', header_style: str = 'Heading 1'):
+        """Insert a header (with specified style) before or after the first paragraph containing target_text. Args: filename (str), target_text (str), header_title (str), position ('before' or 'after'), header_style (str, default 'Heading 1')."""
+        return document_tools.insert_header_near_text_tool(filename, target_text, header_title, position, header_style)
     # Content tools (paragraphs, headings, tables, etc.)
     @mcp.tool()
     def add_paragraph(filename: str, text: str, style: str = None):

--- a/word_document_server/main.py
+++ b/word_document_server/main.py
@@ -120,6 +120,14 @@ def register_tools():
     def insert_header_near_text(filename: str, target_text: str, header_title: str, position: str = 'after', header_style: str = 'Heading 1'):
         """Insert a header (with specified style) before or after the first paragraph containing target_text. Args: filename (str), target_text (str), header_title (str), position ('before' or 'after'), header_style (str, default 'Heading 1')."""
         return document_tools.insert_header_near_text_tool(filename, target_text, header_title, position, header_style)
+    
+    @mcp.tool()
+    def insert_line_or_paragraph_near_text(filename: str, target_text: str, line_text: str, position: str = 'after', line_style: str = None):
+        """
+        Insert a new line or paragraph (with specified or matched style) before or after the first paragraph containing target_text.
+        Args: filename (str), target_text (str), line_text (str), position ('before' or 'after'), line_style (str, optional).
+        """
+        return document_tools.insert_line_or_paragraph_near_text_tool(filename, target_text, line_text, position, line_style)
     # Content tools (paragraphs, headings, tables, etc.)
     @mcp.tool()
     def add_paragraph(filename: str, text: str, style: str = None):

--- a/word_document_server/tools/document_tools.py
+++ b/word_document_server/tools/document_tools.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Any
 from docx import Document
 
 from word_document_server.utils.file_utils import check_file_writeable, ensure_docx_extension, create_document_copy
-from word_document_server.utils.document_utils import get_document_properties, extract_document_text, get_document_structure
+from word_document_server.utils.document_utils import get_document_properties, extract_document_text, get_document_structure, get_document_xml, insert_header_near_text
 from word_document_server.core.styles import ensure_heading_style, ensure_table_style
 
 
@@ -207,3 +207,13 @@ async def merge_documents(target_filename: str, source_filenames: List[str], add
         return f"Successfully merged {len(source_filenames)} documents into {target_filename}"
     except Exception as e:
         return f"Failed to merge documents: {str(e)}"
+
+
+async def get_document_xml_tool(filename: str) -> str:
+    """Get the raw XML structure of a Word document."""
+    return get_document_xml(filename)
+
+
+async def insert_header_near_text_tool(filename: str, target_text: str, header_title: str, position: str = 'after', header_style: str = 'Heading 1') -> str:
+    """Insert a header (with specified style) before or after the first paragraph containing target_text."""
+    return insert_header_near_text(filename, target_text, header_title, position, header_style)

--- a/word_document_server/tools/document_tools.py
+++ b/word_document_server/tools/document_tools.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Any
 from docx import Document
 
 from word_document_server.utils.file_utils import check_file_writeable, ensure_docx_extension, create_document_copy
-from word_document_server.utils.document_utils import get_document_properties, extract_document_text, get_document_structure, get_document_xml, insert_header_near_text
+from word_document_server.utils.document_utils import get_document_properties, extract_document_text, get_document_structure, get_document_xml, insert_header_near_text, insert_line_or_paragraph_near_text
 from word_document_server.core.styles import ensure_heading_style, ensure_table_style
 
 
@@ -217,3 +217,10 @@ async def get_document_xml_tool(filename: str) -> str:
 async def insert_header_near_text_tool(filename: str, target_text: str, header_title: str, position: str = 'after', header_style: str = 'Heading 1') -> str:
     """Insert a header (with specified style) before or after the first paragraph containing target_text."""
     return insert_header_near_text(filename, target_text, header_title, position, header_style)
+
+
+async def insert_line_or_paragraph_near_text_tool(filename: str, target_text: str, line_text: str, position: str = 'after', line_style: str = None) -> str:
+    """
+    Insert a new line or paragraph (with specified or matched style) before or after the first paragraph containing target_text.
+    """
+    return insert_line_or_paragraph_near_text(filename, target_text, line_text, position, line_style)

--- a/word_document_server/utils/document_utils.py
+++ b/word_document_server/utils/document_utils.py
@@ -165,3 +165,45 @@ def find_and_replace_text(doc, old_text, new_text):
                                 count += 1
     
     return count
+
+
+def get_document_xml(doc_path: str) -> str:
+    """Extract and return the raw XML structure of the Word document (word/document.xml)."""
+    import os
+    import zipfile
+    if not os.path.exists(doc_path):
+        return f"Document {doc_path} does not exist"
+    try:
+        with zipfile.ZipFile(doc_path) as docx_zip:
+            with docx_zip.open('word/document.xml') as xml_file:
+                return xml_file.read().decode('utf-8')
+    except Exception as e:
+        return f"Failed to extract XML: {str(e)}"
+
+
+def insert_header_near_text(doc_path: str, target_text: str, header_title: str, position: str = 'after', header_style: str = 'Heading 1') -> str:
+    """Insert a header (with specified style) before or after the first paragraph containing target_text."""
+    import os
+    from docx import Document
+    if not os.path.exists(doc_path):
+        return f"Document {doc_path} does not exist"
+    try:
+        doc = Document(doc_path)
+        found = False
+        for i, para in enumerate(doc.paragraphs):
+            if target_text in para.text:
+                found = True
+                # Create the new header paragraph with the specified style
+                new_para = doc.add_paragraph(header_title, style=header_style)
+                # Move the new paragraph to the correct position
+                if position == 'before':
+                    para._element.addprevious(new_para._element)
+                else:
+                    para._element.addnext(new_para._element)
+                break
+        if not found:
+            return f"Target text '{target_text}' not found in document."
+        doc.save(doc_path)
+        return f"Header '{header_title}' (style: {header_style}) inserted {position} paragraph containing '{target_text}'."
+    except Exception as e:
+        return f"Failed to insert header: {str(e)}"

--- a/word_document_server/utils/document_utils.py
+++ b/word_document_server/utils/document_utils.py
@@ -207,3 +207,34 @@ def insert_header_near_text(doc_path: str, target_text: str, header_title: str, 
         return f"Header '{header_title}' (style: {header_style}) inserted {position} paragraph containing '{target_text}'."
     except Exception as e:
         return f"Failed to insert header: {str(e)}"
+
+
+def insert_line_or_paragraph_near_text(doc_path: str, target_text: str, line_text: str, position: str = 'after', line_style: str = None) -> str:
+    """
+    Insert a new line or paragraph (with specified or matched style) before or after the first paragraph containing target_text.
+    In Word, a new line is a new paragraph.
+    """
+    import os
+    from docx import Document
+    if not os.path.exists(doc_path):
+        return f"Document {doc_path} does not exist"
+    try:
+        doc = Document(doc_path)
+        found = False
+        for i, para in enumerate(doc.paragraphs):
+            if target_text in para.text:
+                found = True
+                # Determine style: use provided or match target
+                style = line_style if line_style else para.style
+                new_para = doc.add_paragraph(line_text, style=style)
+                if position == 'before':
+                    para._element.addprevious(new_para._element)
+                else:
+                    para._element.addnext(new_para._element)
+                break
+        if not found:
+            return f"Target text '{target_text}' not found in document."
+        doc.save(doc_path)
+        return f"Line/paragraph inserted {position} paragraph containing '{target_text}' with style '{style}'."
+    except Exception as e:
+        return f"Failed to insert line/paragraph: {str(e)}"


### PR DESCRIPTION
- Added utility functions to insert lines or paragraphs before or after specific text in Word documents.
- Exposed these utilities as tools in the document_tools module for easier access via the MCP server.
- Improved document information extraction and document structure outlining functions.
- Updated main.py to register the new document manipulation tools with FastMCP.
- Refactored and cleaned up code for better maintainability and clarity.