### PR TITLE
feat: add XML extraction and advanced content manipulation tools 

### DIFF
--- a/word_document_server/main.py
+++ b/word_document_server/main.py
@@ -17,6 +17,9 @@ from word_document_server.tools import (
     footnote_tools,
     extended_document_tools
 )
+from word_document_server.tools.content_tools import replace_paragraph_block_below_header_tool
+from word_document_server.tools.content_tools import replace_block_between_manual_anchors_tool
+
 def get_transport_config():
     """
     Get transport configuration from environment variables.
@@ -117,17 +120,21 @@ def register_tools():
         return document_tools.get_document_xml_tool(filename)
     
     @mcp.tool()
-    def insert_header_near_text(filename: str, target_text: str, header_title: str, position: str = 'after', header_style: str = 'Heading 1'):
-        """Insert a header (with specified style) before or after the first paragraph containing target_text. Args: filename (str), target_text (str), header_title (str), position ('before' or 'after'), header_style (str, default 'Heading 1')."""
-        return document_tools.insert_header_near_text_tool(filename, target_text, header_title, position, header_style)
+    def insert_header_near_text(filename: str, target_text: str = None, header_title: str = None, position: str = 'after', header_style: str = 'Heading 1', target_paragraph_index: int = None):
+        """Insert a header (with specified style) before or after the target paragraph. Specify by text or paragraph index. Args: filename (str), target_text (str, optional), header_title (str), position ('before' or 'after'), header_style (str, default 'Heading 1'), target_paragraph_index (int, optional)."""
+        return content_tools.insert_header_near_text_tool(filename, target_text, header_title, position, header_style, target_paragraph_index)
     
     @mcp.tool()
-    def insert_line_or_paragraph_near_text(filename: str, target_text: str, line_text: str, position: str = 'after', line_style: str = None):
+    def insert_line_or_paragraph_near_text(filename: str, target_text: str = None, line_text: str = None, position: str = 'after', line_style: str = None, target_paragraph_index: int = None):
         """
-        Insert a new line or paragraph (with specified or matched style) before or after the first paragraph containing target_text.
-        Args: filename (str), target_text (str), line_text (str), position ('before' or 'after'), line_style (str, optional).
+        Insert a new line or paragraph (with specified or matched style) before or after the target paragraph. Specify by text or paragraph index. Args: filename (str), target_text (str, optional), line_text (str), position ('before' or 'after'), line_style (str, optional), target_paragraph_index (int, optional).
         """
-        return document_tools.insert_line_or_paragraph_near_text_tool(filename, target_text, line_text, position, line_style)
+        return content_tools.insert_line_or_paragraph_near_text_tool(filename, target_text, line_text, position, line_style, target_paragraph_index)
+    
+    @mcp.tool()
+    def insert_numbered_list_near_text(filename: str, target_text: str = None, list_items: list = None, position: str = 'after', target_paragraph_index: int = None):
+        """Insert a numbered list before or after the target paragraph. Specify by text or paragraph index. Args: filename (str), target_text (str, optional), list_items (list of str), position ('before' or 'after'), target_paragraph_index (int, optional)."""
+        return content_tools.insert_numbered_list_near_text_tool(filename, target_text, list_items, position, target_paragraph_index)
     # Content tools (paragraphs, headings, tables, etc.)
     @mcp.tool()
     def add_paragraph(filename: str, text: str, style: str = None):
@@ -240,6 +247,17 @@ def register_tools():
     def convert_to_pdf(filename: str, output_filename: str = None):
         """Convert a Word document to PDF format."""
         return extended_document_tools.convert_to_pdf(filename, output_filename)
+
+    @mcp.tool()
+    def replace_paragraph_block_below_header(filename: str, header_text: str, new_paragraphs: list, detect_block_end_fn=None):
+        """Reemplaza el bloque de párrafos debajo de un encabezado, evitando modificar TOC."""
+        return replace_paragraph_block_below_header_tool(filename, header_text, new_paragraphs, detect_block_end_fn)
+
+    @mcp.tool()
+    def replace_block_between_manual_anchors(filename: str, start_anchor_text: str, new_paragraphs: list, end_anchor_text: str = None, match_fn=None, new_paragraph_style: str = None):
+        """Replace all content between start_anchor_text and end_anchor_text (or next logical header if not provided)."""
+        return replace_block_between_manual_anchors_tool(filename, start_anchor_text, new_paragraphs, end_anchor_text, match_fn, new_paragraph_style)
+
 
 
 def run_server():

--- a/word_document_server/tools/content_tools.py
+++ b/word_document_server/tools/content_tools.py
@@ -10,7 +10,7 @@ from docx import Document
 from docx.shared import Inches, Pt
 
 from word_document_server.utils.file_utils import check_file_writeable, ensure_docx_extension
-from word_document_server.utils.document_utils import find_and_replace_text
+from word_document_server.utils.document_utils import find_and_replace_text, insert_header_near_text, insert_numbered_list_near_text, insert_line_or_paragraph_near_text, replace_paragraph_block_below_header, replace_block_between_manual_anchors
 from word_document_server.core.styles import ensure_heading_style, ensure_table_style
 
 
@@ -399,3 +399,23 @@ async def search_and_replace(filename: str, find_text: str, replace_text: str) -
             return f"No occurrences of '{find_text}' found."
     except Exception as e:
         return f"Failed to search and replace: {str(e)}"
+
+async def insert_header_near_text_tool(filename: str, target_text: str = None, header_title: str = "", position: str = 'after', header_style: str = 'Heading 1', target_paragraph_index: int = None) -> str:
+    """Insert a header (with specified style) before or after the target paragraph. Specify by text or paragraph index."""
+    return insert_header_near_text(filename, target_text, header_title, position, header_style, target_paragraph_index)
+
+async def insert_numbered_list_near_text_tool(filename: str, target_text: str = None, list_items: list = None, position: str = 'after', target_paragraph_index: int = None) -> str:
+    """Insert a numbered list before or after the target paragraph. Specify by text or paragraph index."""
+    return insert_numbered_list_near_text(filename, target_text, list_items, position, target_paragraph_index)
+
+async def insert_line_or_paragraph_near_text_tool(filename: str, target_text: str = None, line_text: str = "", position: str = 'after', line_style: str = None, target_paragraph_index: int = None) -> str:
+    """Insert a new line or paragraph (with specified or matched style) before or after the target paragraph. Specify by text or paragraph index."""
+    return insert_line_or_paragraph_near_text(filename, target_text, line_text, position, line_style, target_paragraph_index)
+
+async def replace_paragraph_block_below_header_tool(filename: str, header_text: str, new_paragraphs: list, detect_block_end_fn=None) -> str:
+    """Reemplaza el bloque de párrafos debajo de un encabezado, evitando modificar TOC."""
+    return replace_paragraph_block_below_header(filename, header_text, new_paragraphs, detect_block_end_fn)
+
+async def replace_block_between_manual_anchors_tool(filename: str, start_anchor_text: str, new_paragraphs: list, end_anchor_text: str = None, match_fn=None, new_paragraph_style: str = None) -> str:
+    """Replace all content between start_anchor_text and end_anchor_text (or next logical header if not provided)."""
+    return replace_block_between_manual_anchors(filename, start_anchor_text, new_paragraphs, end_anchor_text, match_fn, new_paragraph_style)

--- a/word_document_server/tools/document_tools.py
+++ b/word_document_server/tools/document_tools.py
@@ -212,15 +212,3 @@ async def merge_documents(target_filename: str, source_filenames: List[str], add
 async def get_document_xml_tool(filename: str) -> str:
     """Get the raw XML structure of a Word document."""
     return get_document_xml(filename)
-
-
-async def insert_header_near_text_tool(filename: str, target_text: str, header_title: str, position: str = 'after', header_style: str = 'Heading 1') -> str:
-    """Insert a header (with specified style) before or after the first paragraph containing target_text."""
-    return insert_header_near_text(filename, target_text, header_title, position, header_style)
-
-
-async def insert_line_or_paragraph_near_text_tool(filename: str, target_text: str, line_text: str, position: str = 'after', line_style: str = None) -> str:
-    """
-    Insert a new line or paragraph (with specified or matched style) before or after the first paragraph containing target_text.
-    """
-    return insert_line_or_paragraph_near_text(filename, target_text, line_text, position, line_style)

--- a/word_document_server/tools/format_tools.py
+++ b/word_document_server/tools/format_tools.py
@@ -12,7 +12,6 @@ from docx.enum.text import WD_COLOR_INDEX
 from docx.enum.style import WD_STYLE_TYPE
 
 from word_document_server.utils.file_utils import check_file_writeable, ensure_docx_extension
-from word_document_server.utils.document_utils import find_and_replace_text
 from word_document_server.core.styles import create_style
 from word_document_server.core.tables import apply_table_style
 


### PR DESCRIPTION
feat: Add advanced document manipulation tools for Word MCP server

Add 6 new MCP tools for enhanced Word document manipulation:

- get_document_xml: Extract raw XML structure for debugging and advanced customization
- insert_line_or_paragraph_near_text: Add new lines/paragraphs near existing content with style matching
- insert_numbered_list_near_text: Insert numbered lists for action items, procedures, and checklists
- replace_paragraph_block_below_header: Replace entire sections under headers while preserving structure
- replace_block_between_manual_anchors: Replace content between text anchors or headers

Key improvements:
- Template-friendly operations for document population
- Non-destructive editing that preserves document structure
- Multi-language header support (Spanish "Título", etc.)
- Content Control awareness for Word documents
- Batch operations for replacing entire sections
- Debugging support with XML extraction

Enables advanced use cases for meeting minutes, quarterly reports, and template customization workflows.