### PR TITLE
fix: add missing type hints for MCP tool parameters

### DIFF
--- a/word_document_server/main.py
+++ b/word_document_server/main.py
@@ -139,7 +139,7 @@ def register_tools():
         return content_tools.insert_line_or_paragraph_near_text_tool(filename, target_text, line_text, position, line_style, target_paragraph_index)
     
     @mcp.tool()
-    def insert_numbered_list_near_text(filename: str, target_text: str = None, list_items: list = None, position: str = 'after', target_paragraph_index: int = None, bullet_type: str = 'bullet'):
+    def insert_numbered_list_near_text(filename: str, target_text: str = None, list_items: list[str] = None, position: str = 'after', target_paragraph_index: int = None, bullet_type: str = 'bullet'):
         """Insert a bulleted or numbered list before or after the target paragraph. Specify by text or paragraph index. Args: filename (str), target_text (str, optional), list_items (list of str), position ('before' or 'after'), target_paragraph_index (int, optional), bullet_type ('bullet' for bullets or 'number' for numbered lists, default: 'bullet')."""
         return content_tools.insert_numbered_list_near_text_tool(filename, target_text, list_items, position, target_paragraph_index, bullet_type)
     # Content tools (paragraphs, headings, tables, etc.)
@@ -185,7 +185,7 @@ def register_tools():
         return content_tools.add_picture(filename, image_path, width)
     
     @mcp.tool()
-    def add_table(filename: str, rows: int, cols: int, data: list = None):
+    def add_table(filename: str, rows: int, cols: int, data: list[list[str]] = None):
         """Add a table to a Word document."""
         return content_tools.add_table(filename, rows, cols, data)
     
@@ -227,7 +227,7 @@ def register_tools():
     
     @mcp.tool()
     def format_table(filename: str, table_index: int, has_header_row: bool = None,
-                    border_style: str = None, shading: list = None):
+                    border_style: str = None, shading: list[str] = None):
         """Format a table with borders, shading, and structure."""
         return format_tools.format_table(filename, table_index, has_header_row, border_style, shading)
     
@@ -390,12 +390,12 @@ def register_tools():
         return extended_document_tools.convert_to_pdf(filename, output_filename)
 
     @mcp.tool()
-    def replace_paragraph_block_below_header(filename: str, header_text: str, new_paragraphs: list, detect_block_end_fn=None):
+    def replace_paragraph_block_below_header(filename: str, header_text: str, new_paragraphs: list[str], detect_block_end_fn: str = None):
         """Reemplaza el bloque de párrafos debajo de un encabezado, evitando modificar TOC."""
         return replace_paragraph_block_below_header_tool(filename, header_text, new_paragraphs, detect_block_end_fn)
 
     @mcp.tool()
-    def replace_block_between_manual_anchors(filename: str, start_anchor_text: str, new_paragraphs: list, end_anchor_text: str = None, match_fn=None, new_paragraph_style: str = None):
+    def replace_block_between_manual_anchors(filename: str, start_anchor_text: str, new_paragraphs: list[str], end_anchor_text: str = None, match_fn: str = None, new_paragraph_style: str = None):
         """Replace all content between start_anchor_text and end_anchor_text (or next logical header if not provided)."""
         return replace_block_between_manual_anchors_tool(filename, start_anchor_text, new_paragraphs, end_anchor_text, match_fn, new_paragraph_style)
 
@@ -422,7 +422,7 @@ def register_tools():
         return format_tools.set_table_column_width(filename, table_index, col_index, width, width_type)
 
     @mcp.tool()
-    def set_table_column_widths(filename: str, table_index: int, widths: list, 
+    def set_table_column_widths(filename: str, table_index: int, widths: list[float],
                                width_type: str = "points"):
         """Set the widths of multiple table columns."""
         return format_tools.set_table_column_widths(filename, table_index, widths, width_type)


### PR DESCRIPTION
## Summary
Fix missing type annotations that caused tools to be skipped in Gemini CLI and other MCP clients with strict schema validation.

## Changes
- `insert_numbered_list_near_text`: `list` → `list[str]`
- `add_table`: `list` → `list[list[str]]`
- `format_table`: `list` → `list[str]`
- `replace_paragraph_block_below_header`: `list` → `list[str]`
- `replace_block_between_manual_anchors`: `list` → `list[str]`
- `set_table_column_widths`: `list` → `list[float]`

## Fixes
- Closes #50
- Closes #51
- Closes #52

## Error Before Fix
```
Skipping tool 'insert_numbered_list_near_text' from MCP server 'word-document-server' because it has missing types in its parameter schema.
Skipping tool 'add_table' from MCP server 'word-document-server' because it has missing types in its parameter schema.
...
```

## Test Plan
- [x] Python syntax validation (`python3 -m py_compile`)
- [ ] Test with Gemini CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)