### PR TITLE
fix: add destructiveHint annotation to search_and_replace

### DIFF
--- a/word_document_server/main.py
+++ b/word_document_server/main.py
@@ -275,6 +275,7 @@ def register_tools():
     @mcp.tool(
         annotations=ToolAnnotations(
             title="Search and Replace",
+            destructiveHint=True,
         ),
     )
     def search_and_replace(filename: str, find_text: str, replace_text: str):


### PR DESCRIPTION
## Summary

Follow-up fix for PR #73. The `search_and_replace` tool was missing `destructiveHint=True` in its annotation.

Since this tool modifies document content, it should indicate to AI systems that this operation can make permanent changes.

## Changes

```python
@mcp.tool(
    annotations=ToolAnnotations(
        title="Search and Replace",
        destructiveHint=True,  # Added
    ),
)
def search_and_replace(...)
```

## Test Plan
- [x] Python syntax validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)