### PR TITLE
fix: handle cross-run text matching in search_and_replace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,8 @@ only-include = [
 ]
 sources = ["."]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [project.scripts]
 word_mcp_server = "word_document_server.main:run_server"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,104 @@
+import pytest
+from docx import Document
+from docx.shared import Pt, RGBColor
+
+
+@pytest.fixture
+def make_docx(tmp_path):
+    """Factory fixture: creates a .docx with specified paragraph structure."""
+    def _make(filename="test.docx", paragraphs=None):
+        path = tmp_path / filename
+        doc = Document()
+        for p_spec in (paragraphs or []):
+            if isinstance(p_spec, str):
+                doc.add_paragraph(p_spec)
+            elif isinstance(p_spec, dict):
+                style = p_spec.get("style", "Normal")
+                para = doc.add_paragraph("", style=style)
+                for run_spec in p_spec.get("runs", []):
+                    run = para.add_run(run_spec["text"])
+                    if "bold" in run_spec:
+                        run.bold = run_spec["bold"]
+                    if "italic" in run_spec:
+                        run.italic = run_spec["italic"]
+                    if "font_size" in run_spec:
+                        run.font.size = Pt(run_spec["font_size"])
+                    if "font_name" in run_spec:
+                        run.font.name = run_spec["font_name"]
+        doc.save(str(path))
+        return str(path)
+    return _make
+
+
+@pytest.fixture
+def cross_run_docx(make_docx):
+    """'Hello World' split across two runs."""
+    return make_docx(paragraphs=[
+        {"runs": [{"text": "Hello "}, {"text": "World"}]},
+        "Simple paragraph",
+    ])
+
+
+@pytest.fixture
+def multi_run_formatted_docx(make_docx):
+    """'Hello World' split across runs with different formatting."""
+    return make_docx(paragraphs=[
+        {"runs": [
+            {"text": "Hello ", "bold": True, "font_size": 12},
+            {"text": "World", "bold": False, "font_size": 14},
+        ]},
+    ])
+
+
+@pytest.fixture
+def heading_docx(make_docx):
+    """Document with headings and content blocks."""
+    return make_docx(paragraphs=[
+        {"style": "Heading 1", "runs": [{"text": "Section One"}]},
+        "Content under section one.",
+        "More content.",
+        {"style": "Heading 1", "runs": [{"text": "Section Two"}]},
+        "Content under section two.",
+    ])
+
+
+@pytest.fixture
+def table_docx(tmp_path):
+    """Table with cross-run text in cell(0,0)."""
+    path = tmp_path / "table_test.docx"
+    doc = Document()
+    table = doc.add_table(rows=2, cols=2)
+    cell = table.cell(0, 0)
+    cell.text = ""
+    para = cell.paragraphs[0]
+    para.add_run("Hello ")
+    para.add_run("World")
+    table.cell(0, 1).text = "Other cell"
+    doc.save(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def anchor_docx(tmp_path):
+    """START/END anchor paragraphs with content between."""
+    path = tmp_path / "anchor_test.docx"
+    doc = Document()
+    doc.add_paragraph("--- START ANCHOR ---")
+    doc.add_paragraph("Content to replace 1")
+    doc.add_paragraph("Content to replace 2")
+    doc.add_paragraph("--- END ANCHOR ---")
+    doc.add_paragraph("After the anchors")
+    doc.save(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def nbsp_anchor_docx(tmp_path):
+    """Anchors with NBSP and ZWSP."""
+    path = tmp_path / "nbsp_anchor_test.docx"
+    doc = Document()
+    doc.add_paragraph("---\u00a0START ANCHOR\u00a0---")
+    doc.add_paragraph("Content to replace")
+    doc.add_paragraph("---\u200bEND ANCHOR\u200b---")
+    doc.save(str(path))
+    return str(path)

--- a/tests/test_search_and_replace.py
+++ b/tests/test_search_and_replace.py
@@ -1,0 +1,79 @@
+"""Tests for search_and_replace cross-run text matching (Bug 1)."""
+import pytest
+from docx import Document
+
+from word_document_server.utils.document_utils import find_and_replace_text
+
+
+class TestSingleRunReplace:
+    """Regression: replacement within a single run still works."""
+
+    def test_single_run_replace(self, make_docx):
+        path = make_docx(paragraphs=["Hello World"])
+        doc = Document(path)
+        count = find_and_replace_text(doc, "Hello", "Goodbye")
+        doc.save(path)
+        doc2 = Document(path)
+        assert doc2.paragraphs[0].text == "Goodbye World"
+        assert count >= 1
+
+
+class TestCrossRunReplace:
+    """Text that spans multiple <w:r> elements must be matched and replaced."""
+
+    def test_cross_run_replace(self, cross_run_docx):
+        doc = Document(cross_run_docx)
+        count = find_and_replace_text(doc, "Hello World", "Goodbye Earth")
+        doc.save(cross_run_docx)
+        doc2 = Document(cross_run_docx)
+        assert doc2.paragraphs[0].text == "Goodbye Earth"
+        assert count >= 1
+
+    def test_preserves_first_run_formatting(self, multi_run_formatted_docx):
+        doc = Document(multi_run_formatted_docx)
+        count = find_and_replace_text(doc, "Hello World", "Goodbye Earth")
+        doc.save(multi_run_formatted_docx)
+        doc2 = Document(multi_run_formatted_docx)
+        assert doc2.paragraphs[0].text == "Goodbye Earth"
+        first_run = doc2.paragraphs[0].runs[0]
+        assert first_run.bold is True
+        assert count >= 1
+
+    def test_table_cell_cross_run(self, table_docx):
+        doc = Document(table_docx)
+        count = find_and_replace_text(doc, "Hello World", "Goodbye Earth")
+        doc.save(table_docx)
+        doc2 = Document(table_docx)
+        cell_text = doc2.tables[0].cell(0, 0).text
+        assert cell_text == "Goodbye Earth"
+        assert count >= 1
+
+    def test_no_match_returns_zero(self, make_docx):
+        path = make_docx(paragraphs=["Hello World"])
+        doc = Document(path)
+        count = find_and_replace_text(doc, "Nonexistent", "Replacement")
+        assert count == 0
+
+    def test_multiple_occurrences(self, make_docx):
+        path = make_docx(paragraphs=[
+            {"runs": [{"text": "Hello "}, {"text": "World"}]},
+            {"runs": [{"text": "Hello "}, {"text": "World"}]},
+        ])
+        doc = Document(path)
+        count = find_and_replace_text(doc, "Hello World", "Goodbye Earth")
+        doc.save(path)
+        doc2 = Document(path)
+        assert doc2.paragraphs[0].text == "Goodbye Earth"
+        assert doc2.paragraphs[1].text == "Goodbye Earth"
+        assert count == 2
+
+    def test_toc_paragraphs_skipped(self, tmp_path):
+        path = tmp_path / "toc_test.docx"
+        doc = Document()
+        p = doc.add_paragraph("Hello World")
+        p.style = doc.styles.add_style("TOC 1", 1) if "TOC 1" not in [s.name for s in doc.styles] else doc.styles["TOC 1"]
+        doc.save(str(path))
+        doc2 = Document(str(path))
+        count = find_and_replace_text(doc2, "Hello World", "Goodbye Earth")
+        assert count == 0
+        assert doc2.paragraphs[0].text == "Hello World"


### PR DESCRIPTION
## Summary
- Fix `find_and_replace_text` to handle text that spans multiple XML runs within a paragraph
- Word often splits text across runs due to formatting changes, spell-check marks, or editing history
- New `_replace_in_paragraph()` helper builds a character-to-run map for cross-run matching
- Preserves first run's formatting when replacing across runs
- Skips TOC paragraphs as before

## Test plan
- [x] Single-run replacement still works (regression)
- [x] Cross-run text replacement works
- [x] First run formatting preserved
- [x] Table cell cross-run replacement works
- [x] No match returns zero
- [x] Multiple occurrences replaced
- [x] TOC paragraphs skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)