### PR TITLE
fix: normalize whitespace in header matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,8 @@ only-include = [
 ]
 sources = ["."]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [project.scripts]
 word_mcp_server = "word_document_server.main:run_server"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,104 @@
+import pytest
+from docx import Document
+from docx.shared import Pt, RGBColor
+
+
+@pytest.fixture
+def make_docx(tmp_path):
+    """Factory fixture: creates a .docx with specified paragraph structure."""
+    def _make(filename="test.docx", paragraphs=None):
+        path = tmp_path / filename
+        doc = Document()
+        for p_spec in (paragraphs or []):
+            if isinstance(p_spec, str):
+                doc.add_paragraph(p_spec)
+            elif isinstance(p_spec, dict):
+                style = p_spec.get("style", "Normal")
+                para = doc.add_paragraph("", style=style)
+                for run_spec in p_spec.get("runs", []):
+                    run = para.add_run(run_spec["text"])
+                    if "bold" in run_spec:
+                        run.bold = run_spec["bold"]
+                    if "italic" in run_spec:
+                        run.italic = run_spec["italic"]
+                    if "font_size" in run_spec:
+                        run.font.size = Pt(run_spec["font_size"])
+                    if "font_name" in run_spec:
+                        run.font.name = run_spec["font_name"]
+        doc.save(str(path))
+        return str(path)
+    return _make
+
+
+@pytest.fixture
+def cross_run_docx(make_docx):
+    """'Hello World' split across two runs."""
+    return make_docx(paragraphs=[
+        {"runs": [{"text": "Hello "}, {"text": "World"}]},
+        "Simple paragraph",
+    ])
+
+
+@pytest.fixture
+def multi_run_formatted_docx(make_docx):
+    """'Hello World' split across runs with different formatting."""
+    return make_docx(paragraphs=[
+        {"runs": [
+            {"text": "Hello ", "bold": True, "font_size": 12},
+            {"text": "World", "bold": False, "font_size": 14},
+        ]},
+    ])
+
+
+@pytest.fixture
+def heading_docx(make_docx):
+    """Document with headings and content blocks."""
+    return make_docx(paragraphs=[
+        {"style": "Heading 1", "runs": [{"text": "Section One"}]},
+        "Content under section one.",
+        "More content.",
+        {"style": "Heading 1", "runs": [{"text": "Section Two"}]},
+        "Content under section two.",
+    ])
+
+
+@pytest.fixture
+def table_docx(tmp_path):
+    """Table with cross-run text in cell(0,0)."""
+    path = tmp_path / "table_test.docx"
+    doc = Document()
+    table = doc.add_table(rows=2, cols=2)
+    cell = table.cell(0, 0)
+    cell.text = ""
+    para = cell.paragraphs[0]
+    para.add_run("Hello ")
+    para.add_run("World")
+    table.cell(0, 1).text = "Other cell"
+    doc.save(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def anchor_docx(tmp_path):
+    """START/END anchor paragraphs with content between."""
+    path = tmp_path / "anchor_test.docx"
+    doc = Document()
+    doc.add_paragraph("--- START ANCHOR ---")
+    doc.add_paragraph("Content to replace 1")
+    doc.add_paragraph("Content to replace 2")
+    doc.add_paragraph("--- END ANCHOR ---")
+    doc.add_paragraph("After the anchors")
+    doc.save(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def nbsp_anchor_docx(tmp_path):
+    """Anchors with NBSP and ZWSP."""
+    path = tmp_path / "nbsp_anchor_test.docx"
+    doc = Document()
+    doc.add_paragraph("---\u00a0START ANCHOR\u00a0---")
+    doc.add_paragraph("Content to replace")
+    doc.add_paragraph("---\u200bEND ANCHOR\u200b---")
+    doc.save(str(path))
+    return str(path)

--- a/tests/test_anchor_replace.py
+++ b/tests/test_anchor_replace.py
@@ -1,0 +1,94 @@
+"""Tests for anchor matching normalization (Bug 2)."""
+import pytest
+from docx import Document
+
+from word_document_server.utils.document_utils import replace_block_between_manual_anchors
+
+
+class TestAnchorExactMatch:
+    """Regression: exact anchor matching still works."""
+
+    def test_exact_match_replaces_content(self, anchor_docx):
+        result = replace_block_between_manual_anchors(
+            anchor_docx,
+            start_anchor_text="--- START ANCHOR ---",
+            end_anchor_text="--- END ANCHOR ---",
+            new_paragraphs=["New content A", "New content B"],
+        )
+        assert "not found" not in result.lower()
+        doc = Document(anchor_docx)
+        texts = [p.text for p in doc.paragraphs]
+        assert "New content A" in texts
+        assert "New content B" in texts
+        assert "Content to replace 1" not in texts
+        assert "Content to replace 2" not in texts
+
+
+class TestAnchorNBSP:
+    """NBSP (U+00A0) in document should match regular space in anchor text."""
+
+    def test_nbsp_anchor_matches(self, nbsp_anchor_docx):
+        result = replace_block_between_manual_anchors(
+            nbsp_anchor_docx,
+            start_anchor_text="--- START ANCHOR ---",
+            end_anchor_text="--- END ANCHOR ---",
+            new_paragraphs=["Replaced content"],
+        )
+        assert "not found" not in result.lower()
+        doc = Document(nbsp_anchor_docx)
+        texts = [p.text for p in doc.paragraphs]
+        assert "Replaced content" in texts
+        assert "Content to replace" not in texts
+
+
+class TestAnchorExtraWhitespace:
+    """Extra leading/trailing whitespace should be handled."""
+
+    def test_extra_whitespace_matches(self, tmp_path):
+        path = tmp_path / "ws_test.docx"
+        doc = Document()
+        doc.add_paragraph("  --- START ANCHOR ---  ")
+        doc.add_paragraph("Content to replace")
+        doc.add_paragraph("  --- END ANCHOR ---  ")
+        doc.save(str(path))
+
+        result = replace_block_between_manual_anchors(
+            str(path),
+            start_anchor_text="--- START ANCHOR ---",
+            end_anchor_text="--- END ANCHOR ---",
+            new_paragraphs=["New stuff"],
+        )
+        assert "not found" not in result.lower()
+
+
+class TestAnchorContainsFallback:
+    """Auto-numbering prefix like '1. ' should match via contains fallback."""
+
+    def test_numbered_anchor_matches(self, tmp_path):
+        path = tmp_path / "numbered_test.docx"
+        doc = Document()
+        doc.add_paragraph("1. --- START ANCHOR ---")
+        doc.add_paragraph("Content to replace")
+        doc.add_paragraph("2. --- END ANCHOR ---")
+        doc.save(str(path))
+
+        result = replace_block_between_manual_anchors(
+            str(path),
+            start_anchor_text="--- START ANCHOR ---",
+            end_anchor_text="--- END ANCHOR ---",
+            new_paragraphs=["New stuff"],
+        )
+        assert "not found" not in result.lower()
+
+
+class TestAnchorNotFound:
+    """Non-existent anchor text should return error."""
+
+    def test_anchor_not_found(self, anchor_docx):
+        result = replace_block_between_manual_anchors(
+            anchor_docx,
+            start_anchor_text="NONEXISTENT",
+            end_anchor_text="ALSO NONEXISTENT",
+            new_paragraphs=["New stuff"],
+        )
+        assert "not found" in result.lower()

--- a/tests/test_header_replace.py
+++ b/tests/test_header_replace.py
@@ -1,0 +1,98 @@
+"""Tests for header matching normalization (Bug 3)."""
+import pytest
+from docx import Document
+
+from word_document_server.utils.document_utils import replace_paragraph_block_below_header
+
+
+class TestExactHeadingMatch:
+    """Regression: exact heading match still works."""
+
+    def test_exact_heading_replaces_content(self, heading_docx):
+        result = replace_paragraph_block_below_header(
+            heading_docx,
+            header_text="Section One",
+            new_paragraphs=["New content A", "New content B"],
+        )
+        assert "not found" not in result.lower()
+        doc = Document(heading_docx)
+        texts = [p.text for p in doc.paragraphs]
+        assert "New content A" in texts
+        assert "New content B" in texts
+        assert "Content under section one." not in texts
+        assert "More content." not in texts
+        # Section Two should be untouched
+        assert "Content under section two." in texts
+
+
+class TestHeadingNBSP:
+    """NBSP (U+00A0) in heading should match regular space in search text."""
+
+    def test_nbsp_heading_matches(self, tmp_path):
+        path = tmp_path / "nbsp_heading.docx"
+        doc = Document()
+        p = doc.add_paragraph("Section\u00a0One", style="Heading 1")
+        doc.add_paragraph("Content under section one.")
+        doc.add_paragraph("More content.")
+        p2 = doc.add_paragraph("Section Two", style="Heading 1")
+        doc.add_paragraph("Content under section two.")
+        doc.save(str(path))
+
+        result = replace_paragraph_block_below_header(
+            str(path),
+            header_text="Section One",
+            new_paragraphs=["Replaced"],
+        )
+        assert "not found" not in result.lower()
+        doc2 = Document(str(path))
+        texts = [p.text for p in doc2.paragraphs]
+        assert "Replaced" in texts
+        assert "Content under section one." not in texts
+
+
+class TestHeadingAutoNumbering:
+    """Auto-numbering prefix should match via contains + heading style check."""
+
+    def test_numbered_heading_matches(self, tmp_path):
+        path = tmp_path / "numbered_heading.docx"
+        doc = Document()
+        p = doc.add_paragraph("1. Section One", style="Heading 1")
+        doc.add_paragraph("Content under section one.")
+        p2 = doc.add_paragraph("2. Section Two", style="Heading 1")
+        doc.add_paragraph("Content under section two.")
+        doc.save(str(path))
+
+        result = replace_paragraph_block_below_header(
+            str(path),
+            header_text="Section One",
+            new_paragraphs=["Replaced"],
+        )
+        assert "not found" not in result.lower()
+
+
+class TestHeadingNotFound:
+    """Non-existent heading text should return error."""
+
+    def test_heading_not_found(self, heading_docx):
+        result = replace_paragraph_block_below_header(
+            heading_docx,
+            header_text="NONEXISTENT",
+            new_paragraphs=["New stuff"],
+        )
+        assert "not found" in result.lower()
+
+
+class TestStopsAtNextHeading:
+    """Replacement should stop at the next heading."""
+
+    def test_stops_at_next_heading(self, heading_docx):
+        result = replace_paragraph_block_below_header(
+            heading_docx,
+            header_text="Section One",
+            new_paragraphs=["Only this"],
+        )
+        doc = Document(heading_docx)
+        texts = [p.text for p in doc.paragraphs]
+        # Section Two header and content should still be there
+        assert "Section Two" in texts
+        assert "Content under section two." in texts


### PR DESCRIPTION
## Summary
- Header text matching now uses Unicode NFKC normalization + whitespace collapsing
- Falls back to contains matching with heading-style preference
- Both `delete_block_under_header` and `replace_paragraph_block_below_header` updated
- Shared `_normalize_text()` helper (reused from anchor matching fix)
- Depends on: fix/anchor-matching-normalization

## Test plan
- [x] Exact heading match works (regression)
- [x] NBSP in heading text handled
- [x] Auto-numbering prefix handled via contains + heading style fallback
- [x] Non-existent heading returns clear error
- [x] Replacement stops at next heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)