### PR TITLE
feat: add replace_paragraph_text tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,8 @@ only-include = [
 ]
 sources = ["."]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [project.scripts]
 word_mcp_server = "word_document_server.main:run_server"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,104 @@
+import pytest
+from docx import Document
+from docx.shared import Pt, RGBColor
+
+
+@pytest.fixture
+def make_docx(tmp_path):
+    """Factory fixture: creates a .docx with specified paragraph structure."""
+    def _make(filename="test.docx", paragraphs=None):
+        path = tmp_path / filename
+        doc = Document()
+        for p_spec in (paragraphs or []):
+            if isinstance(p_spec, str):
+                doc.add_paragraph(p_spec)
+            elif isinstance(p_spec, dict):
+                style = p_spec.get("style", "Normal")
+                para = doc.add_paragraph("", style=style)
+                for run_spec in p_spec.get("runs", []):
+                    run = para.add_run(run_spec["text"])
+                    if "bold" in run_spec:
+                        run.bold = run_spec["bold"]
+                    if "italic" in run_spec:
+                        run.italic = run_spec["italic"]
+                    if "font_size" in run_spec:
+                        run.font.size = Pt(run_spec["font_size"])
+                    if "font_name" in run_spec:
+                        run.font.name = run_spec["font_name"]
+        doc.save(str(path))
+        return str(path)
+    return _make
+
+
+@pytest.fixture
+def cross_run_docx(make_docx):
+    """'Hello World' split across two runs."""
+    return make_docx(paragraphs=[
+        {"runs": [{"text": "Hello "}, {"text": "World"}]},
+        "Simple paragraph",
+    ])
+
+
+@pytest.fixture
+def multi_run_formatted_docx(make_docx):
+    """'Hello World' split across runs with different formatting."""
+    return make_docx(paragraphs=[
+        {"runs": [
+            {"text": "Hello ", "bold": True, "font_size": 12},
+            {"text": "World", "bold": False, "font_size": 14},
+        ]},
+    ])
+
+
+@pytest.fixture
+def heading_docx(make_docx):
+    """Document with headings and content blocks."""
+    return make_docx(paragraphs=[
+        {"style": "Heading 1", "runs": [{"text": "Section One"}]},
+        "Content under section one.",
+        "More content.",
+        {"style": "Heading 1", "runs": [{"text": "Section Two"}]},
+        "Content under section two.",
+    ])
+
+
+@pytest.fixture
+def table_docx(tmp_path):
+    """Table with cross-run text in cell(0,0)."""
+    path = tmp_path / "table_test.docx"
+    doc = Document()
+    table = doc.add_table(rows=2, cols=2)
+    cell = table.cell(0, 0)
+    cell.text = ""
+    para = cell.paragraphs[0]
+    para.add_run("Hello ")
+    para.add_run("World")
+    table.cell(0, 1).text = "Other cell"
+    doc.save(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def anchor_docx(tmp_path):
+    """START/END anchor paragraphs with content between."""
+    path = tmp_path / "anchor_test.docx"
+    doc = Document()
+    doc.add_paragraph("--- START ANCHOR ---")
+    doc.add_paragraph("Content to replace 1")
+    doc.add_paragraph("Content to replace 2")
+    doc.add_paragraph("--- END ANCHOR ---")
+    doc.add_paragraph("After the anchors")
+    doc.save(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def nbsp_anchor_docx(tmp_path):
+    """Anchors with NBSP and ZWSP."""
+    path = tmp_path / "nbsp_anchor_test.docx"
+    doc = Document()
+    doc.add_paragraph("---\u00a0START ANCHOR\u00a0---")
+    doc.add_paragraph("Content to replace")
+    doc.add_paragraph("---\u200bEND ANCHOR\u200b---")
+    doc.save(str(path))
+    return str(path)

--- a/tests/test_replace_paragraph.py
+++ b/tests/test_replace_paragraph.py
@@ -1,0 +1,58 @@
+"""Tests for replace_paragraph_text tool (Shortcoming 1)."""
+import pytest
+from docx import Document
+
+from word_document_server.utils.document_utils import replace_paragraph_text
+
+
+class TestBasicReplacement:
+    def test_replace_middle_paragraph(self, make_docx):
+        path = make_docx(paragraphs=["First", "Second", "Third"])
+        result = replace_paragraph_text(path, 1, "Replaced")
+        assert "successfully" in result.lower()
+        doc = Document(path)
+        assert doc.paragraphs[0].text == "First"
+        assert doc.paragraphs[1].text == "Replaced"
+        assert doc.paragraphs[2].text == "Third"
+
+    def test_paragraph_count_unchanged(self, make_docx):
+        path = make_docx(paragraphs=["First", "Second", "Third"])
+        doc_before = Document(path)
+        count_before = len(doc_before.paragraphs)
+        replace_paragraph_text(path, 1, "Replaced")
+        doc_after = Document(path)
+        assert len(doc_after.paragraphs) == count_before
+
+
+class TestStylePreservation:
+    def test_preserves_style_by_default(self, make_docx):
+        path = make_docx(paragraphs=[
+            {"style": "Heading 2", "runs": [{"text": "My Heading"}]},
+            "Body text",
+        ])
+        replace_paragraph_text(path, 0, "New Heading Text")
+        doc = Document(path)
+        assert doc.paragraphs[0].text == "New Heading Text"
+        assert doc.paragraphs[0].style.name == "Heading 2"
+
+    def test_preserve_style_false(self, make_docx):
+        path = make_docx(paragraphs=[
+            {"style": "Heading 2", "runs": [{"text": "My Heading"}]},
+            "Body text",
+        ])
+        replace_paragraph_text(path, 0, "New Text", preserve_style=False)
+        doc = Document(path)
+        assert doc.paragraphs[0].text == "New Text"
+        assert doc.paragraphs[0].style.name == "Normal"
+
+
+class TestInvalidIndex:
+    def test_index_too_large(self, make_docx):
+        path = make_docx(paragraphs=["Only one"])
+        result = replace_paragraph_text(path, 5, "New text")
+        assert "invalid" in result.lower()
+
+    def test_negative_index(self, make_docx):
+        path = make_docx(paragraphs=["Only one"])
+        result = replace_paragraph_text(path, -1, "New text")
+        assert "invalid" in result.lower()

--- a/word_document_server/main.py
+++ b/word_document_server/main.py
@@ -274,6 +274,16 @@ def register_tools():
     
     @mcp.tool(
         annotations=ToolAnnotations(
+            title="Replace Paragraph Text",
+            destructiveHint=True,
+        ),
+    )
+    def replace_paragraph_text(filename: str, paragraph_index: int, new_text: str, preserve_style: bool = True):
+        """Replace the text of a specific paragraph by index, optionally preserving its style."""
+        return content_tools.replace_paragraph_text_tool(filename, paragraph_index, new_text, preserve_style)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
             title="Search and Replace",
             destructiveHint=True,
         ),

--- a/word_document_server/tools/content_tools.py
+++ b/word_document_server/tools/content_tools.py
@@ -10,7 +10,7 @@ from docx import Document
 from docx.shared import Inches, Pt, RGBColor
 
 from word_document_server.utils.file_utils import check_file_writeable, ensure_docx_extension
-from word_document_server.utils.document_utils import find_and_replace_text, insert_header_near_text, insert_numbered_list_near_text, insert_line_or_paragraph_near_text, replace_paragraph_block_below_header, replace_block_between_manual_anchors
+from word_document_server.utils.document_utils import find_and_replace_text, insert_header_near_text, insert_numbered_list_near_text, insert_line_or_paragraph_near_text, replace_paragraph_block_below_header, replace_block_between_manual_anchors, replace_paragraph_text
 from word_document_server.core.styles import ensure_heading_style, ensure_table_style
 
 
@@ -479,3 +479,13 @@ async def replace_paragraph_block_below_header_tool(filename: str, header_text: 
 async def replace_block_between_manual_anchors_tool(filename: str, start_anchor_text: str, new_paragraphs: list, end_anchor_text: str = None, match_fn=None, new_paragraph_style: str = None) -> str:
     """Replace all content between start_anchor_text and end_anchor_text (or next logical header if not provided)."""
     return replace_block_between_manual_anchors(filename, start_anchor_text, new_paragraphs, end_anchor_text, match_fn, new_paragraph_style)
+
+async def replace_paragraph_text_tool(filename: str, paragraph_index: int, new_text: str, preserve_style: bool = True) -> str:
+    """Replace text of a specific paragraph by index."""
+    filename = ensure_docx_extension(filename)
+    if not os.path.exists(filename):
+        return f"Document {filename} does not exist"
+    is_writeable, error_message = check_file_writeable(filename)
+    if not is_writeable:
+        return f"Cannot modify document: {error_message}."
+    return replace_paragraph_text(filename, paragraph_index, new_text, preserve_style)

--- a/word_document_server/utils/document_utils.py
+++ b/word_document_server/utils/document_utils.py
@@ -417,6 +417,41 @@ def insert_numbered_list_near_text(doc_path: str, target_text: str = None, list_
         return f"Failed to insert numbered list: {str(e)}"
 
 
+def replace_paragraph_text(doc_path: str, paragraph_index: int, new_text: str, preserve_style: bool = True) -> str:
+    """Replace the text of a paragraph at a given index, optionally preserving style."""
+    import os
+    if not os.path.exists(doc_path):
+        return f"Document {doc_path} does not exist"
+
+    try:
+        doc = Document(doc_path)
+        if paragraph_index < 0 or paragraph_index >= len(doc.paragraphs):
+            return f"Invalid paragraph index: {paragraph_index}. Document has {len(doc.paragraphs)} paragraphs."
+
+        para = doc.paragraphs[paragraph_index]
+        old_style = para.style
+
+        # Clear all runs
+        for run in para.runs:
+            run.text = ""
+
+        # Set text on first run (preserves its formatting) or add new run
+        if para.runs:
+            para.runs[0].text = new_text
+        else:
+            para.add_run(new_text)
+
+        if preserve_style and old_style:
+            para.style = old_style
+        elif not preserve_style:
+            para.style = doc.styles["Normal"]
+
+        doc.save(doc_path)
+        return f"Paragraph at index {paragraph_index} replaced successfully."
+    except Exception as e:
+        return f"Failed to replace paragraph: {str(e)}"
+
+
 def is_toc_paragraph(para):
     """Devuelve True si el párrafo tiene un estilo de tabla de contenido (TOC)."""
     return para.style and para.style.name.upper().startswith("TOC")


### PR DESCRIPTION
## Summary
- New tool `replace_paragraph_text` replaces text at a given paragraph index in one atomic operation
- Eliminates the error-prone 3-step workflow (get, insert before, delete at shifted index)
- Preserves paragraph style by default (configurable with `preserve_style=False`)
- Preserves first run's formatting

## Test plan
- [x] Basic text replacement works
- [x] Style preserved when preserve_style=True
- [x] Invalid index returns error message
- [x] Paragraph count unchanged after replacement
- [x] preserve_style=False resets to Normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)