### PR TITLE
feat: add batch replace_paragraph_range tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,8 @@ only-include = [
 ]
 sources = ["."]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [project.scripts]
 word_mcp_server = "word_document_server.main:run_server"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,104 @@
+import pytest
+from docx import Document
+from docx.shared import Pt, RGBColor
+
+
+@pytest.fixture
+def make_docx(tmp_path):
+    """Factory fixture: creates a .docx with specified paragraph structure."""
+    def _make(filename="test.docx", paragraphs=None):
+        path = tmp_path / filename
+        doc = Document()
+        for p_spec in (paragraphs or []):
+            if isinstance(p_spec, str):
+                doc.add_paragraph(p_spec)
+            elif isinstance(p_spec, dict):
+                style = p_spec.get("style", "Normal")
+                para = doc.add_paragraph("", style=style)
+                for run_spec in p_spec.get("runs", []):
+                    run = para.add_run(run_spec["text"])
+                    if "bold" in run_spec:
+                        run.bold = run_spec["bold"]
+                    if "italic" in run_spec:
+                        run.italic = run_spec["italic"]
+                    if "font_size" in run_spec:
+                        run.font.size = Pt(run_spec["font_size"])
+                    if "font_name" in run_spec:
+                        run.font.name = run_spec["font_name"]
+        doc.save(str(path))
+        return str(path)
+    return _make
+
+
+@pytest.fixture
+def cross_run_docx(make_docx):
+    """'Hello World' split across two runs."""
+    return make_docx(paragraphs=[
+        {"runs": [{"text": "Hello "}, {"text": "World"}]},
+        "Simple paragraph",
+    ])
+
+
+@pytest.fixture
+def multi_run_formatted_docx(make_docx):
+    """'Hello World' split across runs with different formatting."""
+    return make_docx(paragraphs=[
+        {"runs": [
+            {"text": "Hello ", "bold": True, "font_size": 12},
+            {"text": "World", "bold": False, "font_size": 14},
+        ]},
+    ])
+
+
+@pytest.fixture
+def heading_docx(make_docx):
+    """Document with headings and content blocks."""
+    return make_docx(paragraphs=[
+        {"style": "Heading 1", "runs": [{"text": "Section One"}]},
+        "Content under section one.",
+        "More content.",
+        {"style": "Heading 1", "runs": [{"text": "Section Two"}]},
+        "Content under section two.",
+    ])
+
+
+@pytest.fixture
+def table_docx(tmp_path):
+    """Table with cross-run text in cell(0,0)."""
+    path = tmp_path / "table_test.docx"
+    doc = Document()
+    table = doc.add_table(rows=2, cols=2)
+    cell = table.cell(0, 0)
+    cell.text = ""
+    para = cell.paragraphs[0]
+    para.add_run("Hello ")
+    para.add_run("World")
+    table.cell(0, 1).text = "Other cell"
+    doc.save(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def anchor_docx(tmp_path):
+    """START/END anchor paragraphs with content between."""
+    path = tmp_path / "anchor_test.docx"
+    doc = Document()
+    doc.add_paragraph("--- START ANCHOR ---")
+    doc.add_paragraph("Content to replace 1")
+    doc.add_paragraph("Content to replace 2")
+    doc.add_paragraph("--- END ANCHOR ---")
+    doc.add_paragraph("After the anchors")
+    doc.save(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def nbsp_anchor_docx(tmp_path):
+    """Anchors with NBSP and ZWSP."""
+    path = tmp_path / "nbsp_anchor_test.docx"
+    doc = Document()
+    doc.add_paragraph("---\u00a0START ANCHOR\u00a0---")
+    doc.add_paragraph("Content to replace")
+    doc.add_paragraph("---\u200bEND ANCHOR\u200b---")
+    doc.save(str(path))
+    return str(path)

--- a/tests/test_batch_replace.py
+++ b/tests/test_batch_replace.py
@@ -1,0 +1,65 @@
+"""Tests for replace_paragraph_range tool (Shortcoming 3)."""
+import pytest
+from docx import Document
+
+from word_document_server.utils.document_utils import replace_paragraph_range
+
+
+class TestSameCountReplacement:
+    def test_replace_range_same_count(self, make_docx):
+        path = make_docx(paragraphs=["A", "B", "C", "D", "E"])
+        result = replace_paragraph_range(path, 1, 3, ["X", "Y", "Z"])
+        assert "replaced" in result.lower()
+        doc = Document(path)
+        texts = [p.text for p in doc.paragraphs]
+        assert texts == ["A", "X", "Y", "Z", "E"]
+
+
+class TestFewerReplacements:
+    def test_replace_range_fewer(self, make_docx):
+        path = make_docx(paragraphs=["A", "B", "C", "D", "E"])
+        result = replace_paragraph_range(path, 1, 3, ["X"])
+        assert "replaced" in result.lower()
+        doc = Document(path)
+        texts = [p.text for p in doc.paragraphs]
+        assert texts == ["A", "X", "E"]
+
+
+class TestMoreReplacements:
+    def test_replace_range_more(self, make_docx):
+        path = make_docx(paragraphs=["A", "B", "C", "D", "E"])
+        result = replace_paragraph_range(path, 1, 2, ["X", "Y", "Z", "W"])
+        assert "replaced" in result.lower()
+        doc = Document(path)
+        texts = [p.text for p in doc.paragraphs]
+        assert texts == ["A", "X", "Y", "Z", "W", "D", "E"]
+
+
+class TestInvalidRange:
+    def test_invalid_range_start_too_large(self, make_docx):
+        path = make_docx(paragraphs=["A", "B"])
+        result = replace_paragraph_range(path, 3, 5, ["X"])
+        assert "invalid" in result.lower()
+
+    def test_invalid_range_start_greater_than_end(self, make_docx):
+        path = make_docx(paragraphs=["A", "B", "C"])
+        result = replace_paragraph_range(path, 2, 1, ["X"])
+        assert "invalid" in result.lower()
+
+
+class TestStyleParameter:
+    def test_style_applied(self, make_docx):
+        path = make_docx(paragraphs=["A", "B", "C"])
+        replace_paragraph_range(path, 0, 1, ["X", "Y"], style="Heading 1")
+        doc = Document(path)
+        assert doc.paragraphs[0].style.name == "Heading 1"
+        assert doc.paragraphs[1].style.name == "Heading 1"
+
+
+class TestSingleParagraphRange:
+    def test_single_paragraph(self, make_docx):
+        path = make_docx(paragraphs=["A", "B", "C"])
+        replace_paragraph_range(path, 1, 1, ["X"])
+        doc = Document(path)
+        texts = [p.text for p in doc.paragraphs]
+        assert texts == ["A", "X", "C"]

--- a/word_document_server/main.py
+++ b/word_document_server/main.py
@@ -274,6 +274,17 @@ def register_tools():
     
     @mcp.tool(
         annotations=ToolAnnotations(
+            title="Replace Paragraph Range",
+            destructiveHint=True,
+        ),
+    )
+    def replace_paragraph_range(filename: str, start_index: int, end_index: int,
+                                new_paragraphs: list[str], style: str = None):
+        """Replace a range of paragraphs (start to end index inclusive) with new paragraphs in a single operation."""
+        return content_tools.replace_paragraph_range_tool(filename, start_index, end_index, new_paragraphs, style)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
             title="Search and Replace",
             destructiveHint=True,
         ),

--- a/word_document_server/tools/content_tools.py
+++ b/word_document_server/tools/content_tools.py
@@ -10,7 +10,7 @@ from docx import Document
 from docx.shared import Inches, Pt, RGBColor
 
 from word_document_server.utils.file_utils import check_file_writeable, ensure_docx_extension
-from word_document_server.utils.document_utils import find_and_replace_text, insert_header_near_text, insert_numbered_list_near_text, insert_line_or_paragraph_near_text, replace_paragraph_block_below_header, replace_block_between_manual_anchors
+from word_document_server.utils.document_utils import find_and_replace_text, insert_header_near_text, insert_numbered_list_near_text, insert_line_or_paragraph_near_text, replace_paragraph_block_below_header, replace_block_between_manual_anchors, replace_paragraph_range
 from word_document_server.core.styles import ensure_heading_style, ensure_table_style
 
 
@@ -479,3 +479,14 @@ async def replace_paragraph_block_below_header_tool(filename: str, header_text: 
 async def replace_block_between_manual_anchors_tool(filename: str, start_anchor_text: str, new_paragraphs: list, end_anchor_text: str = None, match_fn=None, new_paragraph_style: str = None) -> str:
     """Replace all content between start_anchor_text and end_anchor_text (or next logical header if not provided)."""
     return replace_block_between_manual_anchors(filename, start_anchor_text, new_paragraphs, end_anchor_text, match_fn, new_paragraph_style)
+
+async def replace_paragraph_range_tool(filename: str, start_index: int, end_index: int,
+                                        new_paragraphs: list, style: str = None) -> str:
+    """Replace a range of paragraphs in a single operation."""
+    filename = ensure_docx_extension(filename)
+    if not os.path.exists(filename):
+        return f"Document {filename} does not exist"
+    is_writeable, error_message = check_file_writeable(filename)
+    if not is_writeable:
+        return f"Cannot modify document: {error_message}."
+    return replace_paragraph_range(filename, start_index, end_index, new_paragraphs, style)


### PR DESCRIPTION
## Summary
- New tool `replace_paragraph_range` replaces a contiguous range of paragraphs in one atomic operation
- Eliminates N individual get/insert/delete calls with manual index recalculation
- Supports replacing N paragraphs with M paragraphs (shrink, expand, or same count)
- Optional style parameter applies to all new paragraphs

## Test plan
- [x] Replace range with same number of paragraphs
- [x] Replace range with fewer paragraphs (shrink)
- [x] Replace range with more paragraphs (expand)
- [x] Invalid range returns error
- [x] Style parameter applies to new paragraphs
- [x] Single-paragraph range works

🤖 Generated with [Claude Code](https://claude.com/claude-code)